### PR TITLE
Fix #26 Location function bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -444,7 +444,7 @@ async function getLocationByStreet(street, zip, searchNearist = true) {
  * @returns 
  */
 async function getLocationByStreetLL(street, zip) {
-  var loc = await getStreetLocation(street, zip);
+  var loc = await getLocationByStreet(street, zip);
   if(loc) {
    loc = util_mgrs.toPoint(loc);
    loc = {


### PR DESCRIPTION
quick typo in `getLocationByStreetLL` referencing a function that doesn't exist, I think it should be calling getLocationByStreet